### PR TITLE
WIP: Add note for setup with Split GPG

### DIFF
--- a/binhost-cron.sh
+++ b/binhost-cron.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+exec {lock_fd}>/home/user/binhost.lock || exit 1
+flock -n "$lock_fd" || { echo "ERROR: flock() failed." >&2; exit 1; }
+
+REMOTE_URL="$1"
+LOG_FILE="/var/log/binhost/$(date -u +%Y%m%dT%H%M%SZ).log"
+
+if [ -n "$REMOTE_URL" ]; then
+    # Ensure trailing / for rsync
+    if [ "${REMOTE_URL: -1}" != "/" ]; then
+        REMOTE_URL="${REMOTE_URL}/"
+    fi
+    sudo emerge -uDN @world --quiet-build --buildpkg --buildpkg-exclude "app-emulation/qubes-*" 2>&1 | tee -a "$LOG_FILE"
+    rsync -e "ssh -o StrictHostKeyChecking=no" -av --progress --no-perms --omit-dir-times /var/cache/binpkgs/ "$REMOTE_URL" | tee -a "$LOG_FILE"
+fi
+
+flock -u "$lock_fd"

--- a/setup.sh
+++ b/setup.sh
@@ -2,22 +2,15 @@
 
 set -ex
 
-emerge app-eselect/eselect-repository
-eselect repository enable gitlab
 emerge --sync
-
-echo 'dev-util/gitlab-runner-bin ~amd64' > /etc/portage/package.accept_keywords/gitlab-runner
-emerge dev-util/gitlab-runner-bin
-
-echo 'gitlab-runner ALL = NOPASSWD: /usr/bin/emerge' > /etc/sudoers.d/gitlab-runner
-
-usermod -aG portage gitlab-runner
-
-systemctl enable gitlab-runner
-systemctl start gitlab-runner
 
 cat >> /etc/portage/make.conf << EOF
 FEATURES="buildpkg binpkg-logs clean-logs split-log"
 PORTAGE_LOGDIR="/var/log/portage"
 PORTAGE_LOGDIR_CLEAN="find \"\${PORTAGE_LOGDIR}\" -type f ! -name \"summary.log*\" -mtime +7 -delete"
 EOF
+
+echo 'user ALL = NOPASSWD: /usr/bin/emerge' > /etc/sudoers.d/user
+
+mkdir /var/log/binhost
+chown user:user /var/log/binhost


### PR DESCRIPTION
This is a WIP for using split GPG in order to provide a secure setup for publishing binpkgs from a Gentoo build host.

- [ ] Adapt make `qubes-gpg-client-wrapper` allowing `--clearsign` and abbreviated `--detach-sig`. The latter should probably be fixed in `portage` directly. We also need to make it ignoring `--homedir`.
- [ ] Verify step does not work (yet). For now, I need to check why and add more debug inside `portage/gpkg.py`.